### PR TITLE
Use POSIX paths for imports.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "prost",
  "prost-types",
  "stylua",
+ "typed-path",
 ]
 
 [[package]]
@@ -950,6 +951,12 @@ dependencies = [
  "thread_local",
  "tracing-core",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069e2cc1d241fd4ff5fa067e8882996fcfce20986d078696e05abccbcf27b43"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ pathdiff = "0.2.1"
 prost = "0.12.3"
 prost-types = "0.12.3"
 stylua = { version = "0.20.0", default-features = false, features = ["luau"] }
+typed-path = "0.8.0"
 
 [profile.dev.package.stylua]
 opt-level = 3

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, collections::HashMap, path::Path};
+use std::{borrow::Cow, collections::HashMap};
+
+use typed_path::UnixPath as Path;
 
 use prost_types::{
     field_descriptor_proto::{Label, Type},


### PR DESCRIPTION
Use POSIX paths for imports.





This fixes an issue where import paths are invalid when running protoc on Windows.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Kampfkarren/protoc-gen-luau/pull/8).
* #13
* #10
* #9
* __->__ #8