### PR TITLE
Properly report JSON encoding failures for out of range timestamps.

### DIFF
--- a/conformance/generated/google/protobuf/timestamp.luau
+++ b/conformance/generated/google/protobuf/timestamp.luau
@@ -110,6 +110,9 @@ end
 
 function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
+	if dateInfo == nil then
+		error("Invalid date provided")
+	end
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/src/luau/wkt_mixins/Timestamp.luau
+++ b/src/luau/wkt_mixins/Timestamp.luau
@@ -19,6 +19,9 @@ end
 
 function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
+	if dateInfo == nil then
+		error("Invalid date provided")
+	end
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/src/tests/tests.luau
+++ b/src/tests/tests.luau
@@ -55,14 +55,36 @@ end
 
 function tests.assertEquals<T>(x: T, y: T)
 	if not deepEqual(x, y) then
-		error(`Assertion failed. Expected {x} to equal {y}`)
+		error(`Assertion failed. Expected \`{x}\` to equal \`{y}\``)
 	end
 end
 
 function tests.assertNotEquals<T>(x: T, y: T)
 	if deepEqual(x, y) then
-		error(`Assertion failed. Expected {x} to not equal {y}`)
+		error(`Assertion failed. Expected \`{x}\` not to equal \`{y}\``)
 	end
+end
+
+function tests.assertStringContains(haystack: string, needle: string)
+	if not string.find(haystack, needle) then
+		error(`Assertion failed. Expected \`{haystack}\` to contain \`{needle}\``)
+	end
+end
+
+function tests.assertThrows(callback: () -> ()): any?
+	local thrown = nil
+	local success = xpcall(callback, function(problem)
+		thrown = problem
+		print("threw")
+	end)
+
+	print("success", success)
+
+	if success then
+		error("Expected an error to be thrown, but it wasn't")
+	end
+
+	return thrown
 end
 
 function tests.finish()

--- a/src/tests/wkt_json.luau
+++ b/src/tests/wkt_json.luau
@@ -7,6 +7,8 @@ local timestamp = require("./samples/google/protobuf/timestamp")
 local wrappers = require("./samples/google/protobuf/wrappers")
 
 local assertEquals = tests.assertEquals
+local assertThrows = tests.assertThrows
+local assertStringContains = tests.assertStringContains
 local describe = tests.describe
 local it = tests.it
 
@@ -139,6 +141,19 @@ describe("JSON round-trips should work for", function()
 			assertEquals(deserialized_timestamp.nanos, 1)
 
 			assertEquals(deserialized_timestamp:jsonEncode(), json)
+		end)
+
+		it("with large seconds", function()
+			-- The maximum timestamp supported by os.date seems to be 32536849999 (1/19/3001 21:53:19).
+			-- However, Timestamp is supposed to support up to 253402322399 (12/31/9999 23:59:59).
+			-- The protobuf conformance test uses 253402300800.
+			local large_timestamp = timestamp.Timestamp.new({ seconds = 253402300800 })
+
+			local error = assertThrows(function()
+				large_timestamp:jsonEncode()
+			end)
+
+			assertStringContains(error :: string, "Invalid date provided")
 		end)
 	end)
 


### PR DESCRIPTION
Properly report JSON encoding failures for out of range timestamps.


Summary:

Test Plan:
