### PR TITLE
Validate that durations are within the valid range when decoding JSON.

### DIFF
--- a/conformance/failing_tests.txt
+++ b/conformance/failing_tests.txt
@@ -24,8 +24,6 @@ Required.Proto3.JsonInput.DoubleFieldMinPositiveValue.JsonOutput
 Required.Proto3.JsonInput.DoubleFieldMinPositiveValue.ProtobufOutput
 Required.Proto3.JsonInput.DoubleFieldTooLarge
 Required.Proto3.JsonInput.DoubleFieldTooSmall
-Required.Proto3.JsonInput.DurationJsonInputTooLarge
-Required.Proto3.JsonInput.DurationJsonInputTooSmall
 Required.Proto3.JsonInput.EnumFieldNotQuoted
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
 Required.Proto3.JsonInput.FloatFieldTooLarge

--- a/conformance/failing_tests.txt
+++ b/conformance/failing_tests.txt
@@ -206,5 +206,4 @@ Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[8].JsonOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[8].ProtobufOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[9].JsonOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT64[2].JsonOutput
-Required.Proto3.TimestampProtoInputTooLarge.JsonOutput
 Required.Proto3.TimestampProtoInputTooSmall.JsonOutput

--- a/conformance/failing_tests.txt
+++ b/conformance/failing_tests.txt
@@ -204,4 +204,3 @@ Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[8].JsonOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[8].ProtobufOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT32[9].JsonOutput
 Required.Proto3.ProtobufInput.ValidDataScalar.UINT64[2].JsonOutput
-Required.Proto3.TimestampProtoInputTooSmall.JsonOutput

--- a/conformance/generated/google/protobuf/duration.luau
+++ b/conformance/generated/google/protobuf/duration.luau
@@ -142,26 +142,31 @@ function _DurationImpl.jsonEncode(duration: Duration): string
 end
 
 function _DurationImpl.jsonDecode(anyValue: any): Duration
+	local maxSeconds = 315576000000
+	local minSeconds = -315576000000
 	local durationString: string = anyValue
 	local simpleSecondsText = string.match(durationString, "^([%-0-9]+)s$")
+	local seconds = 0
+	local nanos = 0
 	if simpleSecondsText ~= nil then
-		local simpleSeconds = assert(
+		seconds = assert(
 			tonumber(simpleSecondsText),
 			"Invalid duration string received--was formatted as just having seconds, but wasn't a properly formatted int"
 		)
+	else
+		local secondsText, nanosText = string.match(durationString, "^([%-0-9]+)%.([0-9]+)s$")
+		assert(secondsText ~= nil, "Invalid duration string received--seconds provided are invalid")
+		assert(nanosText ~= nil, "Invalid duration string received--nanos provided are invalid")
 
-		return Duration.new({
-			seconds = simpleSeconds,
-			nanos = 0,
-		})
+		seconds = assert(tonumber(secondsText), "Invalid duration string received--seconds provided are invalid")
+		nanos = deserializeFractionalNanos(nanosText) * (secondsText:sub(1, 1) == "-" and -1 or 1)
 	end
 
-	local secondsText, nanosText = string.match(durationString, "^([%-0-9]+)%.([0-9]+)s$")
-	assert(secondsText ~= nil, "Invalid duration string received--seconds provided are invalid")
-	assert(nanosText ~= nil, "Invalid duration string received--nanos provided are invalid")
-
-	local seconds = assert(tonumber(secondsText), "Invalid duration string received--seconds provided are invalid")
-	local nanos = deserializeFractionalNanos(nanosText) * (secondsText:sub(1, 1) == "-" and -1 or 1)
+	if seconds > maxSeconds then
+		error(`Duration seconds cannot exceed {maxSeconds}`)
+	elseif seconds < minSeconds then
+		error(`Duration seconds cannot be less than {minSeconds}`)
+	end
 
 	return Duration.new({
 		seconds = seconds,

--- a/conformance/generated/google/protobuf/timestamp.luau
+++ b/conformance/generated/google/protobuf/timestamp.luau
@@ -109,7 +109,13 @@ local function deserializeFractionalNanos(nanosText: string): number
 end
 
 function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
+	if timestamp.seconds > 253402300799 then
+		error("Invalid timestamp provided: years after 9999 are not supported")
+	end
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
+	if dateInfo == nil then
+		error("Invalid timestamp provided: exceeded supported timestamp range on this platform")
+	end
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/conformance/generated/google/protobuf/timestamp.luau
+++ b/conformance/generated/google/protobuf/timestamp.luau
@@ -112,6 +112,9 @@ function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
 	if timestamp.seconds > 253402300799 then
 		error("Invalid timestamp provided: years after 9999 are not supported")
 	end
+	if timestamp.seconds < -62135596800 then
+		error("Invalid timestamp provided: years before 0001 are not supported")
+	end
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
 	if dateInfo == nil then
 		error("Invalid timestamp provided: exceeded supported timestamp range on this platform")

--- a/conformance/generated/google/protobuf/timestamp.luau
+++ b/conformance/generated/google/protobuf/timestamp.luau
@@ -112,13 +112,16 @@ function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
 	if timestamp.seconds > 253402300799 then
 		error("Invalid timestamp provided: years after 9999 are not supported")
 	end
+
 	if timestamp.seconds < -62135596800 then
 		error("Invalid timestamp provided: years before 0001 are not supported")
 	end
+
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
 	if dateInfo == nil then
 		error("Invalid timestamp provided: exceeded supported timestamp range on this platform")
 	end
+
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/src/luau/wkt_mixins/Duration.luau
+++ b/src/luau/wkt_mixins/Duration.luau
@@ -51,26 +51,31 @@ function _DurationImpl.jsonEncode(duration: Duration): string
 end
 
 function _DurationImpl.jsonDecode(anyValue: any): Duration
+	local maxSeconds = 315576000000
+	local minSeconds = -315576000000
 	local durationString: string = anyValue
 	local simpleSecondsText = string.match(durationString, "^([%-0-9]+)s$")
+	local seconds = 0
+	local nanos = 0
 	if simpleSecondsText ~= nil then
-		local simpleSeconds = assert(
+		seconds = assert(
 			tonumber(simpleSecondsText),
 			"Invalid duration string received--was formatted as just having seconds, but wasn't a properly formatted int"
 		)
+	else
+		local secondsText, nanosText = string.match(durationString, "^([%-0-9]+)%.([0-9]+)s$")
+		assert(secondsText ~= nil, "Invalid duration string received--seconds provided are invalid")
+		assert(nanosText ~= nil, "Invalid duration string received--nanos provided are invalid")
 
-		return Duration.new({
-			seconds = simpleSeconds,
-			nanos = 0,
-		})
+		seconds = assert(tonumber(secondsText), "Invalid duration string received--seconds provided are invalid")
+		nanos = deserializeFractionalNanos(nanosText) * (secondsText:sub(1, 1) == "-" and -1 or 1)
 	end
 
-	local secondsText, nanosText = string.match(durationString, "^([%-0-9]+)%.([0-9]+)s$")
-	assert(secondsText ~= nil, "Invalid duration string received--seconds provided are invalid")
-	assert(nanosText ~= nil, "Invalid duration string received--nanos provided are invalid")
-
-	local seconds = assert(tonumber(secondsText), "Invalid duration string received--seconds provided are invalid")
-	local nanos = deserializeFractionalNanos(nanosText) * (secondsText:sub(1, 1) == "-" and -1 or 1)
+	if seconds > maxSeconds then
+		error(`Duration seconds cannot exceed {maxSeconds}`)
+	elseif seconds < minSeconds then
+		error(`Duration seconds cannot be less than {minSeconds}`)
+	end
 
 	return Duration.new({
 		seconds = seconds,

--- a/src/luau/wkt_mixins/Timestamp.luau
+++ b/src/luau/wkt_mixins/Timestamp.luau
@@ -18,7 +18,16 @@ local function deserializeFractionalNanos(nanosText: string): number
 end
 
 function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
+	if timestamp.seconds > 253402300799 then
+		error("Invalid timestamp provided: years after 9999 are not supported")
+	end
+	if timestamp.seconds < -62135596800 then
+		error("Invalid timestamp provided: years before 0001 are not supported")
+	end
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
+	if dateInfo == nil then
+		error("Invalid timestamp provided: exceeded supported timestamp range on this platform")
+	end
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/src/luau/wkt_mixins/Timestamp.luau
+++ b/src/luau/wkt_mixins/Timestamp.luau
@@ -21,13 +21,16 @@ function _TimestampImpl.jsonEncode(timestamp: Timestamp): string
 	if timestamp.seconds > 253402300799 then
 		error("Invalid timestamp provided: years after 9999 are not supported")
 	end
+
 	if timestamp.seconds < -62135596800 then
 		error("Invalid timestamp provided: years before 0001 are not supported")
 	end
+
 	local dateInfo = os.date("!*t", timestamp.seconds or 0)
 	if dateInfo == nil then
 		error("Invalid timestamp provided: exceeded supported timestamp range on this platform")
 	end
+
 	return string.format(
 		"%04d-%02d-%02dT%02d:%02d:%02d%sZ",
 		dateInfo.year,

--- a/src/tests/tests.luau
+++ b/src/tests/tests.luau
@@ -55,14 +55,33 @@ end
 
 function tests.assertEquals<T>(x: T, y: T)
 	if not deepEqual(x, y) then
-		error(`Assertion failed. Expected {x} to equal {y}`)
+		error(`Assertion failed. Expected \`{x}\` to equal \`{y}\``)
 	end
 end
 
 function tests.assertNotEquals<T>(x: T, y: T)
 	if deepEqual(x, y) then
-		error(`Assertion failed. Expected {x} to not equal {y}`)
+		error(`Assertion failed. Expected \`{x}\` not to equal \`{y}\``)
 	end
+end
+
+function tests.assertStringContains(haystack: string, needle: string)
+	if not string.find(haystack, needle) then
+		error(`Assertion failed. Expected \`{haystack}\` to contain \`{needle}\``)
+	end
+end
+
+function tests.assertThrows(callback: () -> ()): any?
+	local thrown = nil
+	local success = xpcall(callback, function(problem)
+		thrown = problem
+	end)
+
+	if success then
+		error("Expected an error to be thrown, but it wasn't")
+	end
+
+	return thrown
 end
 
 function tests.finish()

--- a/src/tests/wkt_json.luau
+++ b/src/tests/wkt_json.luau
@@ -246,6 +246,26 @@ describe("JSON round-trips should work for", function()
 
 			assertEquals(deserialized_duration:jsonEncode(), json)
 		end)
+
+		it("with too many seconds", function()
+			local json = "315576000001s"
+
+			local error = assertThrows(function()
+				duration.Duration.jsonDecode(json)
+			end)
+
+			assertStringContains(error :: string, "Duration seconds cannot exceed 315576000000")
+		end)
+
+		it("with too few seconds", function()
+			local json = "-315576000001s"
+
+			local error = assertThrows(function()
+				duration.Duration.jsonDecode(json)
+			end)
+
+			assertStringContains(error :: string, "Duration seconds cannot be less than %-315576000000")
+		end)
 	end)
 
 	describe("FieldMask", function()

--- a/src/tests/wkt_json.luau
+++ b/src/tests/wkt_json.luau
@@ -7,6 +7,8 @@ local timestamp = require("./samples/google/protobuf/timestamp")
 local wrappers = require("./samples/google/protobuf/wrappers")
 
 local assertEquals = tests.assertEquals
+local assertThrows = tests.assertThrows
+local assertStringContains = tests.assertStringContains
 local describe = tests.describe
 local it = tests.it
 
@@ -139,6 +141,31 @@ describe("JSON round-trips should work for", function()
 			assertEquals(deserialized_timestamp.nanos, 1)
 
 			assertEquals(deserialized_timestamp:jsonEncode(), json)
+		end)
+
+		it("with large seconds", function()
+			-- The maximum timestamp supported by os.date on Windows 11 seems to be 32536849999 (1/19/3001 21:53:19).
+			-- However, Timestamp is supposed to support up to 253402300799 (12/31/9999 23:59:59).
+			-- The protobuf conformance test uses 253402300800.
+			local large_timestamp = timestamp.Timestamp.new({ seconds = 253402300800 })
+
+			local error = assertThrows(function()
+				large_timestamp:jsonEncode()
+			end)
+
+			assertStringContains(error :: string, "Invalid timestamp provided")
+		end)
+
+		it("with small seconds", function()
+			-- This comes from the TimestampProtoInputTooSmall conformance test, which currently fails,
+			-- even though this test passes...?
+			local small_timestamp = timestamp.Timestamp.new({ seconds = -62135596801 })
+
+			local error = assertThrows(function()
+				small_timestamp:jsonEncode()
+			end)
+
+			assertStringContains(error :: string, "Invalid timestamp provided")
 		end)
 	end)
 


### PR DESCRIPTION
Validate that durations are within the valid range when decoding JSON.

This fixes two failing conformance tests.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Kampfkarren/protoc-gen-luau/pull/30).
* __->__ #30
* #29