### PR TITLE
Auto-wrap nested message fields in .new()

### DIFF
--- a/conformance/generated/conformance.luau
+++ b/conformance/generated/conformance.luau
@@ -30,7 +30,7 @@ type _FailureSetFields = {
 	failure: { string },
 }
 
-type _FailureSetPartialFields = {
+export type _FailureSetPartialFields = {
 	failure: { string }?,
 }
 
@@ -61,7 +61,7 @@ type _ConformanceRequestFields = {
 	print_unknown_fields: boolean,
 }
 
-type _ConformanceRequestPartialFields = {
+export type _ConformanceRequestPartialFields = {
 	payload: (
 		{ type: "protobuf_payload", value: buffer }
 		| { type: "json_payload", value: string }
@@ -71,7 +71,7 @@ type _ConformanceRequestPartialFields = {
 	requested_output_format: WireFormat?,
 	message_type: string?,
 	test_category: TestCategory?,
-	jspb_encoding_options: JspbEncodingConfig?,
+	jspb_encoding_options: (JspbEncodingConfig | _JspbEncodingConfigPartialFields)?,
 	print_unknown_fields: boolean?,
 }
 
@@ -102,7 +102,7 @@ type _ConformanceResponseFields = {
 	)?,
 }
 
-type _ConformanceResponsePartialFields = {
+export type _ConformanceResponsePartialFields = {
 	result: (
 		{ type: "parse_error", value: string }
 		| { type: "serialize_error", value: string }
@@ -133,7 +133,7 @@ type _JspbEncodingConfigFields = {
 	use_jspb_array_any_format: boolean,
 }
 
-type _JspbEncodingConfigPartialFields = {
+export type _JspbEncodingConfigPartialFields = {
 	use_jspb_array_any_format: boolean?,
 }
 
@@ -277,7 +277,10 @@ do
 				else data.test_category,
 			jspb_encoding_options = if data == nil or data.jspb_encoding_options == nil
 				then nil
-				else data.jspb_encoding_options,
+				elseif getmetatable(data.jspb_encoding_options :: any) == nil then messages.JspbEncodingConfig.new(
+					data.jspb_encoding_options :: any
+				)
+				else (data.jspb_encoding_options :: any) :: JspbEncodingConfig,
 			print_unknown_fields = if data == nil or data.print_unknown_fields == nil
 				then false
 				else data.print_unknown_fields,

--- a/conformance/generated/google/protobuf/any.luau
+++ b/conformance/generated/google/protobuf/any.luau
@@ -40,7 +40,7 @@ type _AnyFields = {
 	value: buffer,
 }
 
-type _AnyPartialFields = {
+export type _AnyPartialFields = {
 	type_url: string?,
 	value: buffer?,
 }

--- a/conformance/generated/google/protobuf/duration.luau
+++ b/conformance/generated/google/protobuf/duration.luau
@@ -26,7 +26,7 @@ type _DurationFields = {
 	nanos: number,
 }
 
-type _DurationPartialFields = {
+export type _DurationPartialFields = {
 	seconds: number?,
 	nanos: number?,
 }

--- a/conformance/generated/google/protobuf/field_mask.luau
+++ b/conformance/generated/google/protobuf/field_mask.luau
@@ -25,7 +25,7 @@ type _FieldMaskFields = {
 	paths: { string },
 }
 
-type _FieldMaskPartialFields = {
+export type _FieldMaskPartialFields = {
 	paths: { string }?,
 }
 

--- a/conformance/generated/google/protobuf/struct.luau
+++ b/conformance/generated/google/protobuf/struct.luau
@@ -29,8 +29,8 @@ type _StructFields = {
 	fields: { [string]: Value },
 }
 
-type _StructPartialFields = {
-	fields: { [string]: Value }?,
+export type _StructPartialFields = {
+	fields: { [string]: any }?,
 }
 
 export type Struct = typeof(setmetatable({} :: _StructFields, {} :: _StructImpl))
@@ -51,9 +51,9 @@ type _Struct_FieldsEntryFields = {
 	value: Value?,
 }
 
-type _Struct_FieldsEntryPartialFields = {
+export type _Struct_FieldsEntryPartialFields = {
 	key: string?,
-	value: Value?,
+	value: (Value | _ValuePartialFields)?,
 }
 
 export type Struct_FieldsEntry = typeof(setmetatable({} :: _Struct_FieldsEntryFields, {} :: _Struct_FieldsEntryImpl))
@@ -80,14 +80,14 @@ type _ValueFields = {
 	)?,
 }
 
-type _ValuePartialFields = {
+export type _ValuePartialFields = {
 	kind: (
 		{ type: "null_value", value: NullValue }
 		| { type: "number_value", value: number }
 		| { type: "string_value", value: string }
 		| { type: "bool_value", value: boolean }
-		| { type: "struct_value", value: Struct }
-		| { type: "list_value", value: ListValue }
+		| { type: "struct_value", value: Struct | _StructPartialFields }
+		| { type: "list_value", value: ListValue | _ListValuePartialFields }
 	)?,
 }
 
@@ -108,8 +108,8 @@ type _ListValueFields = {
 	values: { Value },
 }
 
-type _ListValuePartialFields = {
-	values: { Value }?,
+export type _ListValuePartialFields = {
+	values: { Value | _ValuePartialFields }?,
 }
 
 export type ListValue = typeof(setmetatable({} :: _ListValueFields, {} :: _ListValueImpl))
@@ -124,7 +124,17 @@ do
 
 	function _StructImpl.new(data: _StructPartialFields?): Struct
 		return setmetatable({
-			fields = if data == nil or data.fields == nil then {} else data.fields,
+			fields = (function()
+				local src = if data == nil then nil else data.fields
+				if src == nil then
+					return {}
+				end
+				local out = {}
+				for k, v in src do
+					out[k] = if getmetatable(v :: any) == nil then messages.Value.new(v :: any) else (v :: any) :: Value
+				end
+				return out
+			end)(),
 		}, _StructImpl :: _StructImpl)
 	end
 
@@ -240,7 +250,10 @@ do
 	function _Struct_FieldsEntryImpl.new(data: _Struct_FieldsEntryPartialFields?): Struct_FieldsEntry
 		return setmetatable({
 			key = if data == nil or data.key == nil then "" else data.key,
-			value = if data == nil or data.value == nil then nil else data.value,
+			value = if data == nil or data.value == nil
+				then nil
+				elseif getmetatable(data.value :: any) == nil then messages.Value.new(data.value :: any)
+				else (data.value :: any) :: Value,
 		}, _Struct_FieldsEntryImpl :: _Struct_FieldsEntryImpl)
 	end
 
@@ -356,7 +369,26 @@ do
 
 	function _ValueImpl.new(data: _ValuePartialFields?): Value
 		return setmetatable({
-			kind = if data == nil or data.kind == nil then nil else data.kind,
+			kind = (function()
+				if data == nil or data.kind == nil then
+					return nil
+				end
+				local v = data.kind
+				if
+					(v :: any).type == "struct_value"
+					and (v :: any).value ~= nil
+					and getmetatable((v :: any).value) == nil
+				then
+					return { type = (v :: any).type, value = messages.Struct.new((v :: any).value) } :: any
+				elseif
+					(v :: any).type == "list_value"
+					and (v :: any).value ~= nil
+					and getmetatable((v :: any).value) == nil
+				then
+					return { type = (v :: any).type, value = messages.ListValue.new((v :: any).value) } :: any
+				end
+				return v :: any
+			end)(),
 		}, _ValueImpl :: _ValueImpl)
 	end
 
@@ -529,7 +561,17 @@ do
 
 	function _ListValueImpl.new(data: _ListValuePartialFields?): ListValue
 		return setmetatable({
-			values = if data == nil or data.values == nil then {} else data.values,
+			values = (function()
+				local src = if data == nil then nil else data.values
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil then messages.Value.new(v :: any) else (v :: any) :: Value
+				end
+				return out
+			end)(),
 		}, _ListValueImpl :: _ListValueImpl)
 	end
 

--- a/conformance/generated/google/protobuf/timestamp.luau
+++ b/conformance/generated/google/protobuf/timestamp.luau
@@ -26,7 +26,7 @@ type _TimestampFields = {
 	nanos: number,
 }
 
-type _TimestampPartialFields = {
+export type _TimestampPartialFields = {
 	seconds: number?,
 	nanos: number?,
 }

--- a/conformance/generated/google/protobuf/wrappers.luau
+++ b/conformance/generated/google/protobuf/wrappers.luau
@@ -33,7 +33,7 @@ type _DoubleValueFields = {
 	value: number,
 }
 
-type _DoubleValuePartialFields = {
+export type _DoubleValuePartialFields = {
 	value: number?,
 }
 
@@ -54,7 +54,7 @@ type _FloatValueFields = {
 	value: number,
 }
 
-type _FloatValuePartialFields = {
+export type _FloatValuePartialFields = {
 	value: number?,
 }
 
@@ -75,7 +75,7 @@ type _Int64ValueFields = {
 	value: number,
 }
 
-type _Int64ValuePartialFields = {
+export type _Int64ValuePartialFields = {
 	value: number?,
 }
 
@@ -96,7 +96,7 @@ type _UInt64ValueFields = {
 	value: number,
 }
 
-type _UInt64ValuePartialFields = {
+export type _UInt64ValuePartialFields = {
 	value: number?,
 }
 
@@ -117,7 +117,7 @@ type _Int32ValueFields = {
 	value: number,
 }
 
-type _Int32ValuePartialFields = {
+export type _Int32ValuePartialFields = {
 	value: number?,
 }
 
@@ -138,7 +138,7 @@ type _UInt32ValueFields = {
 	value: number,
 }
 
-type _UInt32ValuePartialFields = {
+export type _UInt32ValuePartialFields = {
 	value: number?,
 }
 
@@ -159,7 +159,7 @@ type _BoolValueFields = {
 	value: boolean,
 }
 
-type _BoolValuePartialFields = {
+export type _BoolValuePartialFields = {
 	value: boolean?,
 }
 
@@ -180,7 +180,7 @@ type _StringValueFields = {
 	value: string,
 }
 
-type _StringValuePartialFields = {
+export type _StringValuePartialFields = {
 	value: string?,
 }
 
@@ -201,7 +201,7 @@ type _BytesValueFields = {
 	value: buffer,
 }
 
-type _BytesValuePartialFields = {
+export type _BytesValuePartialFields = {
 	value: buffer?,
 }
 

--- a/conformance/generated/test_messages_proto3.luau
+++ b/conformance/generated/test_messages_proto3.luau
@@ -211,7 +211,7 @@ type _TestAllTypesProto3Fields = {
 	Field_name18__: number,
 }
 
-type _TestAllTypesProto3PartialFields = {
+export type _TestAllTypesProto3PartialFields = {
 	optional_int32: number?,
 	optional_int64: number?,
 	optional_uint32: number?,
@@ -227,14 +227,14 @@ type _TestAllTypesProto3PartialFields = {
 	optional_bool: boolean?,
 	optional_string: string?,
 	optional_bytes: buffer?,
-	optional_nested_message: TestAllTypesProto3_NestedMessage?,
-	optional_foreign_message: ForeignMessage?,
+	optional_nested_message: (TestAllTypesProto3_NestedMessage | _TestAllTypesProto3_NestedMessagePartialFields)?,
+	optional_foreign_message: (ForeignMessage | _ForeignMessagePartialFields)?,
 	optional_nested_enum: TestAllTypesProto3_NestedEnum?,
 	optional_foreign_enum: ForeignEnum?,
 	optional_aliased_enum: TestAllTypesProto3_AliasedEnum?,
 	optional_string_piece: string?,
 	optional_cord: string?,
-	recursive_message: TestAllTypesProto3?,
+	recursive_message: (TestAllTypesProto3 | _TestAllTypesProto3PartialFields)?,
 	repeated_int32: { number }?,
 	repeated_int64: { number }?,
 	repeated_uint32: { number }?,
@@ -250,8 +250,8 @@ type _TestAllTypesProto3PartialFields = {
 	repeated_bool: { boolean }?,
 	repeated_string: { string }?,
 	repeated_bytes: { buffer }?,
-	repeated_nested_message: { TestAllTypesProto3_NestedMessage }?,
-	repeated_foreign_message: { ForeignMessage }?,
+	repeated_nested_message: { TestAllTypesProto3_NestedMessage | _TestAllTypesProto3_NestedMessagePartialFields }?,
+	repeated_foreign_message: { ForeignMessage | _ForeignMessagePartialFields }?,
 	repeated_nested_enum: { TestAllTypesProto3_NestedEnum }?,
 	repeated_foreign_enum: { ForeignEnum }?,
 	repeated_string_piece: { string }?,
@@ -299,13 +299,16 @@ type _TestAllTypesProto3PartialFields = {
 	map_bool_bool: { [boolean]: boolean }?,
 	map_string_string: { [string]: string }?,
 	map_string_bytes: { [string]: buffer }?,
-	map_string_nested_message: { [string]: TestAllTypesProto3_NestedMessage }?,
-	map_string_foreign_message: { [string]: ForeignMessage }?,
+	map_string_nested_message: { [string]: any }?,
+	map_string_foreign_message: { [string]: any }?,
 	map_string_nested_enum: { [string]: TestAllTypesProto3_NestedEnum }?,
 	map_string_foreign_enum: { [string]: ForeignEnum }?,
 	oneof_field: (
 		{ type: "oneof_uint32", value: number }
-		| { type: "oneof_nested_message", value: TestAllTypesProto3_NestedMessage }
+		| {
+			type: "oneof_nested_message",
+			value: TestAllTypesProto3_NestedMessage | _TestAllTypesProto3_NestedMessagePartialFields,
+		}
 		| { type: "oneof_string", value: string }
 		| { type: "oneof_bytes", value: buffer }
 		| { type: "oneof_bool", value: boolean }
@@ -315,38 +318,78 @@ type _TestAllTypesProto3PartialFields = {
 		| { type: "oneof_enum", value: TestAllTypesProto3_NestedEnum }
 		| { type: "oneof_null_value", value: _google_protobuf_struct.NullValue }
 	)?,
-	optional_bool_wrapper: _google_protobuf_wrappers.BoolValue?,
-	optional_int32_wrapper: _google_protobuf_wrappers.Int32Value?,
-	optional_int64_wrapper: _google_protobuf_wrappers.Int64Value?,
-	optional_uint32_wrapper: _google_protobuf_wrappers.UInt32Value?,
-	optional_uint64_wrapper: _google_protobuf_wrappers.UInt64Value?,
-	optional_float_wrapper: _google_protobuf_wrappers.FloatValue?,
-	optional_double_wrapper: _google_protobuf_wrappers.DoubleValue?,
-	optional_string_wrapper: _google_protobuf_wrappers.StringValue?,
-	optional_bytes_wrapper: _google_protobuf_wrappers.BytesValue?,
-	repeated_bool_wrapper: { _google_protobuf_wrappers.BoolValue }?,
-	repeated_int32_wrapper: { _google_protobuf_wrappers.Int32Value }?,
-	repeated_int64_wrapper: { _google_protobuf_wrappers.Int64Value }?,
-	repeated_uint32_wrapper: { _google_protobuf_wrappers.UInt32Value }?,
-	repeated_uint64_wrapper: { _google_protobuf_wrappers.UInt64Value }?,
-	repeated_float_wrapper: { _google_protobuf_wrappers.FloatValue }?,
-	repeated_double_wrapper: { _google_protobuf_wrappers.DoubleValue }?,
-	repeated_string_wrapper: { _google_protobuf_wrappers.StringValue }?,
-	repeated_bytes_wrapper: { _google_protobuf_wrappers.BytesValue }?,
-	optional_duration: _google_protobuf_duration.Duration?,
-	optional_timestamp: _google_protobuf_timestamp.Timestamp?,
-	optional_field_mask: _google_protobuf_field_mask.FieldMask?,
-	optional_struct: _google_protobuf_struct.Struct?,
-	optional_any: _google_protobuf_any.Any?,
-	optional_value: _google_protobuf_struct.Value?,
+	optional_bool_wrapper: (_google_protobuf_wrappers.BoolValue | _google_protobuf_wrappers._BoolValuePartialFields)?,
+	optional_int32_wrapper: (_google_protobuf_wrappers.Int32Value | _google_protobuf_wrappers._Int32ValuePartialFields)?,
+	optional_int64_wrapper: (_google_protobuf_wrappers.Int64Value | _google_protobuf_wrappers._Int64ValuePartialFields)?,
+	optional_uint32_wrapper: (
+		_google_protobuf_wrappers.UInt32Value | _google_protobuf_wrappers._UInt32ValuePartialFields
+	)?,
+	optional_uint64_wrapper: (
+		_google_protobuf_wrappers.UInt64Value | _google_protobuf_wrappers._UInt64ValuePartialFields
+	)?,
+	optional_float_wrapper: (_google_protobuf_wrappers.FloatValue | _google_protobuf_wrappers._FloatValuePartialFields)?,
+	optional_double_wrapper: (
+		_google_protobuf_wrappers.DoubleValue | _google_protobuf_wrappers._DoubleValuePartialFields
+	)?,
+	optional_string_wrapper: (
+		_google_protobuf_wrappers.StringValue | _google_protobuf_wrappers._StringValuePartialFields
+	)?,
+	optional_bytes_wrapper: (_google_protobuf_wrappers.BytesValue | _google_protobuf_wrappers._BytesValuePartialFields)?,
+	repeated_bool_wrapper: { _google_protobuf_wrappers.BoolValue | _google_protobuf_wrappers._BoolValuePartialFields }?,
+	repeated_int32_wrapper: {
+		(
+			_google_protobuf_wrappers.Int32Value | _google_protobuf_wrappers._Int32ValuePartialFields
+		)
+	}?,
+	repeated_int64_wrapper: {
+		(
+			_google_protobuf_wrappers.Int64Value | _google_protobuf_wrappers._Int64ValuePartialFields
+		)
+	}?,
+	repeated_uint32_wrapper: {
+		(
+			_google_protobuf_wrappers.UInt32Value | _google_protobuf_wrappers._UInt32ValuePartialFields
+		)
+	}?,
+	repeated_uint64_wrapper: {
+		(
+			_google_protobuf_wrappers.UInt64Value | _google_protobuf_wrappers._UInt64ValuePartialFields
+		)
+	}?,
+	repeated_float_wrapper: {
+		(
+			_google_protobuf_wrappers.FloatValue | _google_protobuf_wrappers._FloatValuePartialFields
+		)
+	}?,
+	repeated_double_wrapper: {
+		(
+			_google_protobuf_wrappers.DoubleValue | _google_protobuf_wrappers._DoubleValuePartialFields
+		)
+	}?,
+	repeated_string_wrapper: {
+		(
+			_google_protobuf_wrappers.StringValue | _google_protobuf_wrappers._StringValuePartialFields
+		)
+	}?,
+	repeated_bytes_wrapper: {
+		(
+			_google_protobuf_wrappers.BytesValue | _google_protobuf_wrappers._BytesValuePartialFields
+		)
+	}?,
+	optional_duration: (_google_protobuf_duration.Duration | _google_protobuf_duration._DurationPartialFields)?,
+	optional_timestamp: (_google_protobuf_timestamp.Timestamp | _google_protobuf_timestamp._TimestampPartialFields)?,
+	optional_field_mask: (_google_protobuf_field_mask.FieldMask | _google_protobuf_field_mask._FieldMaskPartialFields)?,
+	optional_struct: (_google_protobuf_struct.Struct | _google_protobuf_struct._StructPartialFields)?,
+	optional_any: (_google_protobuf_any.Any | _google_protobuf_any._AnyPartialFields)?,
+	optional_value: (_google_protobuf_struct.Value | _google_protobuf_struct._ValuePartialFields)?,
 	optional_null_value: _google_protobuf_struct.NullValue?,
-	repeated_duration: { _google_protobuf_duration.Duration }?,
-	repeated_timestamp: { _google_protobuf_timestamp.Timestamp }?,
-	repeated_fieldmask: { _google_protobuf_field_mask.FieldMask }?,
-	repeated_struct: { _google_protobuf_struct.Struct }?,
-	repeated_any: { _google_protobuf_any.Any }?,
-	repeated_value: { _google_protobuf_struct.Value }?,
-	repeated_list_value: { _google_protobuf_struct.ListValue }?,
+	repeated_duration: { _google_protobuf_duration.Duration | _google_protobuf_duration._DurationPartialFields }?,
+	repeated_timestamp: { _google_protobuf_timestamp.Timestamp | _google_protobuf_timestamp._TimestampPartialFields }?,
+	repeated_fieldmask: { _google_protobuf_field_mask.FieldMask | _google_protobuf_field_mask._FieldMaskPartialFields }?,
+	repeated_struct: { _google_protobuf_struct.Struct | _google_protobuf_struct._StructPartialFields }?,
+	repeated_any: { _google_protobuf_any.Any | _google_protobuf_any._AnyPartialFields }?,
+	repeated_value: { _google_protobuf_struct.Value | _google_protobuf_struct._ValuePartialFields }?,
+	repeated_list_value: { _google_protobuf_struct.ListValue | _google_protobuf_struct._ListValuePartialFields }?,
 	fieldname1: number?,
 	field_name2: number?,
 	_field_name3: number?,
@@ -385,9 +428,9 @@ type _TestAllTypesProto3_NestedMessageFields = {
 	corecursive: TestAllTypesProto3?,
 }
 
-type _TestAllTypesProto3_NestedMessagePartialFields = {
+export type _TestAllTypesProto3_NestedMessagePartialFields = {
 	a: number?,
-	corecursive: TestAllTypesProto3?,
+	corecursive: (TestAllTypesProto3 | _TestAllTypesProto3PartialFields)?,
 }
 
 export type TestAllTypesProto3_NestedMessage = typeof(setmetatable(
@@ -414,7 +457,7 @@ type _TestAllTypesProto3_MapInt32Int32EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapInt32Int32EntryPartialFields = {
+export type _TestAllTypesProto3_MapInt32Int32EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -443,7 +486,7 @@ type _TestAllTypesProto3_MapInt64Int64EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapInt64Int64EntryPartialFields = {
+export type _TestAllTypesProto3_MapInt64Int64EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -472,7 +515,7 @@ type _TestAllTypesProto3_MapUint32Uint32EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapUint32Uint32EntryPartialFields = {
+export type _TestAllTypesProto3_MapUint32Uint32EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -501,7 +544,7 @@ type _TestAllTypesProto3_MapUint64Uint64EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapUint64Uint64EntryPartialFields = {
+export type _TestAllTypesProto3_MapUint64Uint64EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -530,7 +573,7 @@ type _TestAllTypesProto3_MapSint32Sint32EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapSint32Sint32EntryPartialFields = {
+export type _TestAllTypesProto3_MapSint32Sint32EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -559,7 +602,7 @@ type _TestAllTypesProto3_MapSint64Sint64EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapSint64Sint64EntryPartialFields = {
+export type _TestAllTypesProto3_MapSint64Sint64EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -590,7 +633,7 @@ type _TestAllTypesProto3_MapFixed32Fixed32EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapFixed32Fixed32EntryPartialFields = {
+export type _TestAllTypesProto3_MapFixed32Fixed32EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -621,7 +664,7 @@ type _TestAllTypesProto3_MapFixed64Fixed64EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapFixed64Fixed64EntryPartialFields = {
+export type _TestAllTypesProto3_MapFixed64Fixed64EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -652,7 +695,7 @@ type _TestAllTypesProto3_MapSfixed32Sfixed32EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapSfixed32Sfixed32EntryPartialFields = {
+export type _TestAllTypesProto3_MapSfixed32Sfixed32EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -683,7 +726,7 @@ type _TestAllTypesProto3_MapSfixed64Sfixed64EntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapSfixed64Sfixed64EntryPartialFields = {
+export type _TestAllTypesProto3_MapSfixed64Sfixed64EntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -712,7 +755,7 @@ type _TestAllTypesProto3_MapInt32FloatEntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapInt32FloatEntryPartialFields = {
+export type _TestAllTypesProto3_MapInt32FloatEntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -741,7 +784,7 @@ type _TestAllTypesProto3_MapInt32DoubleEntryFields = {
 	value: number,
 }
 
-type _TestAllTypesProto3_MapInt32DoubleEntryPartialFields = {
+export type _TestAllTypesProto3_MapInt32DoubleEntryPartialFields = {
 	key: number?,
 	value: number?,
 }
@@ -770,7 +813,7 @@ type _TestAllTypesProto3_MapBoolBoolEntryFields = {
 	value: boolean,
 }
 
-type _TestAllTypesProto3_MapBoolBoolEntryPartialFields = {
+export type _TestAllTypesProto3_MapBoolBoolEntryPartialFields = {
 	key: boolean?,
 	value: boolean?,
 }
@@ -799,7 +842,7 @@ type _TestAllTypesProto3_MapStringStringEntryFields = {
 	value: string,
 }
 
-type _TestAllTypesProto3_MapStringStringEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringStringEntryPartialFields = {
 	key: string?,
 	value: string?,
 }
@@ -828,7 +871,7 @@ type _TestAllTypesProto3_MapStringBytesEntryFields = {
 	value: buffer,
 }
 
-type _TestAllTypesProto3_MapStringBytesEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringBytesEntryPartialFields = {
 	key: string?,
 	value: buffer?,
 }
@@ -859,9 +902,9 @@ type _TestAllTypesProto3_MapStringNestedMessageEntryFields = {
 	value: TestAllTypesProto3_NestedMessage?,
 }
 
-type _TestAllTypesProto3_MapStringNestedMessageEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringNestedMessageEntryPartialFields = {
 	key: string?,
-	value: TestAllTypesProto3_NestedMessage?,
+	value: (TestAllTypesProto3_NestedMessage | _TestAllTypesProto3_NestedMessagePartialFields)?,
 }
 
 export type TestAllTypesProto3_MapStringNestedMessageEntry = typeof(setmetatable(
@@ -890,9 +933,9 @@ type _TestAllTypesProto3_MapStringForeignMessageEntryFields = {
 	value: ForeignMessage?,
 }
 
-type _TestAllTypesProto3_MapStringForeignMessageEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringForeignMessageEntryPartialFields = {
 	key: string?,
-	value: ForeignMessage?,
+	value: (ForeignMessage | _ForeignMessagePartialFields)?,
 }
 
 export type TestAllTypesProto3_MapStringForeignMessageEntry = typeof(setmetatable(
@@ -921,7 +964,7 @@ type _TestAllTypesProto3_MapStringNestedEnumEntryFields = {
 	value: TestAllTypesProto3_NestedEnum,
 }
 
-type _TestAllTypesProto3_MapStringNestedEnumEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringNestedEnumEntryPartialFields = {
 	key: string?,
 	value: TestAllTypesProto3_NestedEnum?,
 }
@@ -952,7 +995,7 @@ type _TestAllTypesProto3_MapStringForeignEnumEntryFields = {
 	value: ForeignEnum,
 }
 
-type _TestAllTypesProto3_MapStringForeignEnumEntryPartialFields = {
+export type _TestAllTypesProto3_MapStringForeignEnumEntryPartialFields = {
 	key: string?,
 	value: ForeignEnum?,
 }
@@ -986,7 +1029,7 @@ type _ForeignMessageFields = {
 	c: number,
 }
 
-type _ForeignMessagePartialFields = {
+export type _ForeignMessagePartialFields = {
 	c: number?,
 }
 
@@ -1005,7 +1048,7 @@ type _NullHypothesisProto3Impl = {
 
 type _NullHypothesisProto3Fields = {}
 
-type _NullHypothesisProto3PartialFields = {}
+export type _NullHypothesisProto3PartialFields = {}
 
 export type NullHypothesisProto3 = typeof(setmetatable(
 	{} :: _NullHypothesisProto3Fields,
@@ -1025,7 +1068,7 @@ type _EnumOnlyProto3Impl = {
 
 type _EnumOnlyProto3Fields = {}
 
-type _EnumOnlyProto3PartialFields = {}
+export type _EnumOnlyProto3PartialFields = {}
 
 export type EnumOnlyProto3 = typeof(setmetatable({} :: _EnumOnlyProto3Fields, {} :: _EnumOnlyProto3Impl))
 type _EnumOnlyProto3Message = proto.Message<EnumOnlyProto3, _EnumOnlyProto3PartialFields>
@@ -1061,10 +1104,16 @@ do
 				else data.optional_bytes,
 			optional_nested_message = if data == nil or data.optional_nested_message == nil
 				then nil
-				else data.optional_nested_message,
+				elseif
+					getmetatable(data.optional_nested_message :: any) == nil
+				then messages.TestAllTypesProto3_NestedMessage.new(data.optional_nested_message :: any)
+				else (data.optional_nested_message :: any) :: TestAllTypesProto3_NestedMessage,
 			optional_foreign_message = if data == nil or data.optional_foreign_message == nil
 				then nil
-				else data.optional_foreign_message,
+				elseif getmetatable(data.optional_foreign_message :: any) == nil then messages.ForeignMessage.new(
+					data.optional_foreign_message :: any
+				)
+				else (data.optional_foreign_message :: any) :: ForeignMessage,
 			optional_nested_enum = if data == nil or data.optional_nested_enum == nil
 				then assert(messages.TestAllTypesProto3_NestedEnum.fromNumber(0), "Enum has no 0 default")
 				else data.optional_nested_enum,
@@ -1078,7 +1127,12 @@ do
 				then ""
 				else data.optional_string_piece,
 			optional_cord = if data == nil or data.optional_cord == nil then "" else data.optional_cord,
-			recursive_message = if data == nil or data.recursive_message == nil then nil else data.recursive_message,
+			recursive_message = if data == nil or data.recursive_message == nil
+				then nil
+				elseif getmetatable(data.recursive_message :: any) == nil then messages.TestAllTypesProto3.new(
+					data.recursive_message :: any
+				)
+				else (data.recursive_message :: any) :: TestAllTypesProto3,
 			repeated_int32 = if data == nil or data.repeated_int32 == nil then {} else data.repeated_int32,
 			repeated_int64 = if data == nil or data.repeated_int64 == nil then {} else data.repeated_int64,
 			repeated_uint32 = if data == nil or data.repeated_uint32 == nil then {} else data.repeated_uint32,
@@ -1094,12 +1148,32 @@ do
 			repeated_bool = if data == nil or data.repeated_bool == nil then {} else data.repeated_bool,
 			repeated_string = if data == nil or data.repeated_string == nil then {} else data.repeated_string,
 			repeated_bytes = if data == nil or data.repeated_bytes == nil then {} else data.repeated_bytes,
-			repeated_nested_message = if data == nil or data.repeated_nested_message == nil
-				then {}
-				else data.repeated_nested_message,
-			repeated_foreign_message = if data == nil or data.repeated_foreign_message == nil
-				then {}
-				else data.repeated_foreign_message,
+			repeated_nested_message = (function()
+				local src = if data == nil then nil else data.repeated_nested_message
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then messages.TestAllTypesProto3_NestedMessage.new(v :: any)
+						else (v :: any) :: TestAllTypesProto3_NestedMessage
+				end
+				return out
+			end)(),
+			repeated_foreign_message = (function()
+				local src = if data == nil then nil else data.repeated_foreign_message
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then messages.ForeignMessage.new(v :: any)
+						else (v :: any) :: ForeignMessage
+				end
+				return out
+			end)(),
 			repeated_nested_enum = if data == nil or data.repeated_nested_enum == nil
 				then {}
 				else data.repeated_nested_enum,
@@ -1163,93 +1237,356 @@ do
 			map_bool_bool = if data == nil or data.map_bool_bool == nil then {} else data.map_bool_bool,
 			map_string_string = if data == nil or data.map_string_string == nil then {} else data.map_string_string,
 			map_string_bytes = if data == nil or data.map_string_bytes == nil then {} else data.map_string_bytes,
-			map_string_nested_message = if data == nil or data.map_string_nested_message == nil
-				then {}
-				else data.map_string_nested_message,
-			map_string_foreign_message = if data == nil or data.map_string_foreign_message == nil
-				then {}
-				else data.map_string_foreign_message,
+			map_string_nested_message = (function()
+				local src = if data == nil then nil else data.map_string_nested_message
+				if src == nil then
+					return {}
+				end
+				local out = {}
+				for k, v in src do
+					out[k] = if getmetatable(v :: any) == nil
+						then messages.TestAllTypesProto3_NestedMessage.new(v :: any)
+						else (v :: any) :: TestAllTypesProto3_NestedMessage
+				end
+				return out
+			end)(),
+			map_string_foreign_message = (function()
+				local src = if data == nil then nil else data.map_string_foreign_message
+				if src == nil then
+					return {}
+				end
+				local out = {}
+				for k, v in src do
+					out[k] = if getmetatable(v :: any) == nil
+						then messages.ForeignMessage.new(v :: any)
+						else (v :: any) :: ForeignMessage
+				end
+				return out
+			end)(),
 			map_string_nested_enum = if data == nil or data.map_string_nested_enum == nil
 				then {}
 				else data.map_string_nested_enum,
 			map_string_foreign_enum = if data == nil or data.map_string_foreign_enum == nil
 				then {}
 				else data.map_string_foreign_enum,
-			oneof_field = if data == nil or data.oneof_field == nil then nil else data.oneof_field,
+			oneof_field = (function()
+				if data == nil or data.oneof_field == nil then
+					return nil
+				end
+				local v = data.oneof_field
+				if
+					(v :: any).type == "oneof_nested_message"
+					and (v :: any).value ~= nil
+					and getmetatable((v :: any).value) == nil
+				then
+					return {
+						type = (v :: any).type,
+						value = messages.TestAllTypesProto3_NestedMessage.new((v :: any).value),
+					} :: any
+				end
+				return v :: any
+			end)(),
 			optional_bool_wrapper = if data == nil or data.optional_bool_wrapper == nil
 				then nil
-				else data.optional_bool_wrapper,
+				elseif
+					getmetatable(data.optional_bool_wrapper :: any) == nil
+				then _google_protobuf_wrappers.BoolValue.new(data.optional_bool_wrapper :: any)
+				else (data.optional_bool_wrapper :: any) :: _google_protobuf_wrappers.BoolValue,
 			optional_int32_wrapper = if data == nil or data.optional_int32_wrapper == nil
 				then nil
-				else data.optional_int32_wrapper,
+				elseif
+					getmetatable(data.optional_int32_wrapper :: any) == nil
+				then _google_protobuf_wrappers.Int32Value.new(data.optional_int32_wrapper :: any)
+				else (data.optional_int32_wrapper :: any) :: _google_protobuf_wrappers.Int32Value,
 			optional_int64_wrapper = if data == nil or data.optional_int64_wrapper == nil
 				then nil
-				else data.optional_int64_wrapper,
+				elseif
+					getmetatable(data.optional_int64_wrapper :: any) == nil
+				then _google_protobuf_wrappers.Int64Value.new(data.optional_int64_wrapper :: any)
+				else (data.optional_int64_wrapper :: any) :: _google_protobuf_wrappers.Int64Value,
 			optional_uint32_wrapper = if data == nil or data.optional_uint32_wrapper == nil
 				then nil
-				else data.optional_uint32_wrapper,
+				elseif
+					getmetatable(data.optional_uint32_wrapper :: any) == nil
+				then _google_protobuf_wrappers.UInt32Value.new(data.optional_uint32_wrapper :: any)
+				else (data.optional_uint32_wrapper :: any) :: _google_protobuf_wrappers.UInt32Value,
 			optional_uint64_wrapper = if data == nil or data.optional_uint64_wrapper == nil
 				then nil
-				else data.optional_uint64_wrapper,
+				elseif
+					getmetatable(data.optional_uint64_wrapper :: any) == nil
+				then _google_protobuf_wrappers.UInt64Value.new(data.optional_uint64_wrapper :: any)
+				else (data.optional_uint64_wrapper :: any) :: _google_protobuf_wrappers.UInt64Value,
 			optional_float_wrapper = if data == nil or data.optional_float_wrapper == nil
 				then nil
-				else data.optional_float_wrapper,
+				elseif
+					getmetatable(data.optional_float_wrapper :: any) == nil
+				then _google_protobuf_wrappers.FloatValue.new(data.optional_float_wrapper :: any)
+				else (data.optional_float_wrapper :: any) :: _google_protobuf_wrappers.FloatValue,
 			optional_double_wrapper = if data == nil or data.optional_double_wrapper == nil
 				then nil
-				else data.optional_double_wrapper,
+				elseif
+					getmetatable(data.optional_double_wrapper :: any) == nil
+				then _google_protobuf_wrappers.DoubleValue.new(data.optional_double_wrapper :: any)
+				else (data.optional_double_wrapper :: any) :: _google_protobuf_wrappers.DoubleValue,
 			optional_string_wrapper = if data == nil or data.optional_string_wrapper == nil
 				then nil
-				else data.optional_string_wrapper,
+				elseif
+					getmetatable(data.optional_string_wrapper :: any) == nil
+				then _google_protobuf_wrappers.StringValue.new(data.optional_string_wrapper :: any)
+				else (data.optional_string_wrapper :: any) :: _google_protobuf_wrappers.StringValue,
 			optional_bytes_wrapper = if data == nil or data.optional_bytes_wrapper == nil
 				then nil
-				else data.optional_bytes_wrapper,
-			repeated_bool_wrapper = if data == nil or data.repeated_bool_wrapper == nil
-				then {}
-				else data.repeated_bool_wrapper,
-			repeated_int32_wrapper = if data == nil or data.repeated_int32_wrapper == nil
-				then {}
-				else data.repeated_int32_wrapper,
-			repeated_int64_wrapper = if data == nil or data.repeated_int64_wrapper == nil
-				then {}
-				else data.repeated_int64_wrapper,
-			repeated_uint32_wrapper = if data == nil or data.repeated_uint32_wrapper == nil
-				then {}
-				else data.repeated_uint32_wrapper,
-			repeated_uint64_wrapper = if data == nil or data.repeated_uint64_wrapper == nil
-				then {}
-				else data.repeated_uint64_wrapper,
-			repeated_float_wrapper = if data == nil or data.repeated_float_wrapper == nil
-				then {}
-				else data.repeated_float_wrapper,
-			repeated_double_wrapper = if data == nil or data.repeated_double_wrapper == nil
-				then {}
-				else data.repeated_double_wrapper,
-			repeated_string_wrapper = if data == nil or data.repeated_string_wrapper == nil
-				then {}
-				else data.repeated_string_wrapper,
-			repeated_bytes_wrapper = if data == nil or data.repeated_bytes_wrapper == nil
-				then {}
-				else data.repeated_bytes_wrapper,
-			optional_duration = if data == nil or data.optional_duration == nil then nil else data.optional_duration,
-			optional_timestamp = if data == nil or data.optional_timestamp == nil then nil else data.optional_timestamp,
+				elseif
+					getmetatable(data.optional_bytes_wrapper :: any) == nil
+				then _google_protobuf_wrappers.BytesValue.new(data.optional_bytes_wrapper :: any)
+				else (data.optional_bytes_wrapper :: any) :: _google_protobuf_wrappers.BytesValue,
+			repeated_bool_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_bool_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.BoolValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.BoolValue
+				end
+				return out
+			end)(),
+			repeated_int32_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_int32_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.Int32Value.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.Int32Value
+				end
+				return out
+			end)(),
+			repeated_int64_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_int64_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.Int64Value.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.Int64Value
+				end
+				return out
+			end)(),
+			repeated_uint32_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_uint32_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.UInt32Value.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.UInt32Value
+				end
+				return out
+			end)(),
+			repeated_uint64_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_uint64_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.UInt64Value.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.UInt64Value
+				end
+				return out
+			end)(),
+			repeated_float_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_float_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.FloatValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.FloatValue
+				end
+				return out
+			end)(),
+			repeated_double_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_double_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.DoubleValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.DoubleValue
+				end
+				return out
+			end)(),
+			repeated_string_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_string_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.StringValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.StringValue
+				end
+				return out
+			end)(),
+			repeated_bytes_wrapper = (function()
+				local src = if data == nil then nil else data.repeated_bytes_wrapper
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_wrappers.BytesValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_wrappers.BytesValue
+				end
+				return out
+			end)(),
+			optional_duration = if data == nil or data.optional_duration == nil
+				then nil
+				elseif getmetatable(data.optional_duration :: any) == nil then _google_protobuf_duration.Duration.new(
+					data.optional_duration :: any
+				)
+				else (data.optional_duration :: any) :: _google_protobuf_duration.Duration,
+			optional_timestamp = if data == nil or data.optional_timestamp == nil
+				then nil
+				elseif
+					getmetatable(data.optional_timestamp :: any) == nil
+				then _google_protobuf_timestamp.Timestamp.new(data.optional_timestamp :: any)
+				else (data.optional_timestamp :: any) :: _google_protobuf_timestamp.Timestamp,
 			optional_field_mask = if data == nil or data.optional_field_mask == nil
 				then nil
-				else data.optional_field_mask,
-			optional_struct = if data == nil or data.optional_struct == nil then nil else data.optional_struct,
-			optional_any = if data == nil or data.optional_any == nil then nil else data.optional_any,
-			optional_value = if data == nil or data.optional_value == nil then nil else data.optional_value,
+				elseif
+					getmetatable(data.optional_field_mask :: any) == nil
+				then _google_protobuf_field_mask.FieldMask.new(data.optional_field_mask :: any)
+				else (data.optional_field_mask :: any) :: _google_protobuf_field_mask.FieldMask,
+			optional_struct = if data == nil or data.optional_struct == nil
+				then nil
+				elseif getmetatable(data.optional_struct :: any) == nil then _google_protobuf_struct.Struct.new(
+					data.optional_struct :: any
+				)
+				else (data.optional_struct :: any) :: _google_protobuf_struct.Struct,
+			optional_any = if data == nil or data.optional_any == nil
+				then nil
+				elseif getmetatable(data.optional_any :: any) == nil then _google_protobuf_any.Any.new(
+					data.optional_any :: any
+				)
+				else (data.optional_any :: any) :: _google_protobuf_any.Any,
+			optional_value = if data == nil or data.optional_value == nil
+				then nil
+				elseif getmetatable(data.optional_value :: any) == nil then _google_protobuf_struct.Value.new(
+					data.optional_value :: any
+				)
+				else (data.optional_value :: any) :: _google_protobuf_struct.Value,
 			optional_null_value = if data == nil or data.optional_null_value == nil
 				then assert(_google_protobuf_struct.NullValue.fromNumber(0), "Enum has no 0 default")
 				else data.optional_null_value,
-			repeated_duration = if data == nil or data.repeated_duration == nil then {} else data.repeated_duration,
-			repeated_timestamp = if data == nil or data.repeated_timestamp == nil then {} else data.repeated_timestamp,
-			repeated_fieldmask = if data == nil or data.repeated_fieldmask == nil then {} else data.repeated_fieldmask,
-			repeated_struct = if data == nil or data.repeated_struct == nil then {} else data.repeated_struct,
-			repeated_any = if data == nil or data.repeated_any == nil then {} else data.repeated_any,
-			repeated_value = if data == nil or data.repeated_value == nil then {} else data.repeated_value,
-			repeated_list_value = if data == nil or data.repeated_list_value == nil
-				then {}
-				else data.repeated_list_value,
+			repeated_duration = (function()
+				local src = if data == nil then nil else data.repeated_duration
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_duration.Duration.new(v :: any)
+						else (v :: any) :: _google_protobuf_duration.Duration
+				end
+				return out
+			end)(),
+			repeated_timestamp = (function()
+				local src = if data == nil then nil else data.repeated_timestamp
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_timestamp.Timestamp.new(v :: any)
+						else (v :: any) :: _google_protobuf_timestamp.Timestamp
+				end
+				return out
+			end)(),
+			repeated_fieldmask = (function()
+				local src = if data == nil then nil else data.repeated_fieldmask
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_field_mask.FieldMask.new(v :: any)
+						else (v :: any) :: _google_protobuf_field_mask.FieldMask
+				end
+				return out
+			end)(),
+			repeated_struct = (function()
+				local src = if data == nil then nil else data.repeated_struct
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_struct.Struct.new(v :: any)
+						else (v :: any) :: _google_protobuf_struct.Struct
+				end
+				return out
+			end)(),
+			repeated_any = (function()
+				local src = if data == nil then nil else data.repeated_any
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_any.Any.new(v :: any)
+						else (v :: any) :: _google_protobuf_any.Any
+				end
+				return out
+			end)(),
+			repeated_value = (function()
+				local src = if data == nil then nil else data.repeated_value
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_struct.Value.new(v :: any)
+						else (v :: any) :: _google_protobuf_struct.Value
+				end
+				return out
+			end)(),
+			repeated_list_value = (function()
+				local src = if data == nil then nil else data.repeated_list_value
+				if src == nil then
+					return {}
+				end
+				local out = table.create(#src)
+				for i, v in src do
+					out[i] = if getmetatable(v :: any) == nil
+						then _google_protobuf_struct.ListValue.new(v :: any)
+						else (v :: any) :: _google_protobuf_struct.ListValue
+				end
+				return out
+			end)(),
 			fieldname1 = if data == nil or data.fieldname1 == nil then 0 else data.fieldname1,
 			field_name2 = if data == nil or data.field_name2 == nil then 0 else data.field_name2,
 			_field_name3 = if data == nil or data._field_name3 == nil then 0 else data._field_name3,
@@ -6984,7 +7321,12 @@ do
 	): TestAllTypesProto3_NestedMessage
 		return setmetatable({
 			a = if data == nil or data.a == nil then 0 else data.a,
-			corecursive = if data == nil or data.corecursive == nil then nil else data.corecursive,
+			corecursive = if data == nil or data.corecursive == nil
+				then nil
+				elseif getmetatable(data.corecursive :: any) == nil then messages.TestAllTypesProto3.new(
+					data.corecursive :: any
+				)
+				else (data.corecursive :: any) :: TestAllTypesProto3,
 		}, _TestAllTypesProto3_NestedMessageImpl :: _TestAllTypesProto3_NestedMessageImpl)
 	end
 
@@ -8929,7 +9271,12 @@ do
 	): TestAllTypesProto3_MapStringNestedMessageEntry
 		return setmetatable({
 			key = if data == nil or data.key == nil then "" else data.key,
-			value = if data == nil or data.value == nil then nil else data.value,
+			value = if data == nil or data.value == nil
+				then nil
+				elseif getmetatable(data.value :: any) == nil then messages.TestAllTypesProto3_NestedMessage.new(
+					data.value :: any
+				)
+				else (data.value :: any) :: TestAllTypesProto3_NestedMessage,
 		}, _TestAllTypesProto3_MapStringNestedMessageEntryImpl :: _TestAllTypesProto3_MapStringNestedMessageEntryImpl)
 	end
 
@@ -9056,7 +9403,10 @@ do
 	): TestAllTypesProto3_MapStringForeignMessageEntry
 		return setmetatable({
 			key = if data == nil or data.key == nil then "" else data.key,
-			value = if data == nil or data.value == nil then nil else data.value,
+			value = if data == nil or data.value == nil
+				then nil
+				elseif getmetatable(data.value :: any) == nil then messages.ForeignMessage.new(data.value :: any)
+				else (data.value :: any) :: ForeignMessage,
 		}, _TestAllTypesProto3_MapStringForeignMessageEntryImpl :: _TestAllTypesProto3_MapStringForeignMessageEntryImpl)
 	end
 

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -142,6 +142,75 @@ impl FieldGenerator<'_> {
         definition
     }
 
+    /// Same shape as `type_definition_no_presence`, but for message-typed
+    /// positions widens to `<Type> | _<Type>PartialFields` so callers can
+    /// pass either a constructed instance or a plain-table partial.
+    /// Mirrors the runtime `getmetatable(v) == nil then .new(v) else v`
+    /// auto-wrap branch.
+    ///
+    /// Maps with message values use `{ [K]: any }` rather than the union —
+    /// Luau treats indexed table types as invariant in their value, so an
+    /// object-literal map like `{ foo = { value = "x" } }` cannot fit a
+    /// `{ [K]: A | B }` slot even when each value would be assignable to
+    /// `A | B` individually.
+    pub fn partial_input_type_definition_no_presence(&self) -> String {
+        match &self.field_kind {
+            FieldKind::Single(field) => {
+                if let Some(map_type) = self.map_type() {
+                    let value = if map_type.value.r#type() == Type::Message {
+                        "any".to_owned()
+                    } else {
+                        type_definition_of_field_descriptor(
+                            &map_type.value,
+                            self.export_map,
+                            self.base_file,
+                        )
+                    };
+                    format!(
+                        "{{ [{}]: {} }}",
+                        type_definition_of_field_descriptor(
+                            &map_type.key,
+                            self.export_map,
+                            self.base_file
+                        ),
+                        value,
+                    )
+                } else {
+                    let definition = partial_input_definition_of_field_descriptor(
+                        field,
+                        self.export_map,
+                        self.base_file,
+                    );
+
+                    if field.label.is_some() && field.label() == Label::Repeated {
+                        format!("{{ {definition} }}")
+                    } else {
+                        definition
+                    }
+                }
+            }
+
+            FieldKind::OneOf { fields, .. } => {
+                let variants = fields
+                    .iter()
+                    .map(|field| {
+                        format!(
+                            "{{ type: \"{}\", value: {} }}",
+                            self.luau_name(field.name()),
+                            partial_input_definition_of_field_descriptor(
+                                field,
+                                self.export_map,
+                                self.base_file
+                            )
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                format!("({})", variants.join(" | "))
+            }
+        }
+    }
+
     pub fn should_encode(&self) -> String {
         let this = format!("self.{}", self.name());
 
@@ -541,13 +610,18 @@ impl FieldGenerator<'_> {
                             self.export_map,
                             self.base_file,
                         );
+                        let value_type_name = type_definition_of_field_descriptor(
+                            &map_type.value,
+                            self.export_map,
+                            self.base_file,
+                        );
                         return format!(
                             "{field_name} = (function()\n\
                                 local src = if data == nil then nil else data.{field_name}\n\
                                 if src == nil then return {{}} end\n\
                                 local out = {{}}\n\
                                 for k, v in src do\n\
-                                    out[k] = if getmetatable(v :: any) == nil then {value_type}.new(v) else v\n\
+                                    out[k] = if getmetatable(v :: any) == nil then {value_type}.new(v :: any) else (v :: any) :: {value_type_name}\n\
                                 end\n\
                                 return out\n\
                             end)(),"
@@ -566,13 +640,18 @@ impl FieldGenerator<'_> {
                             self.export_map,
                             self.base_file,
                         );
+                        let msg_type_name = type_definition_of_field_descriptor(
+                            field,
+                            self.export_map,
+                            self.base_file,
+                        );
                         return format!(
                             "{field_name} = (function()\n\
                                 local src = if data == nil then nil else data.{field_name}\n\
                                 if src == nil then return {{}} end\n\
                                 local out = table.create(#src)\n\
                                 for i, v in src do\n\
-                                    out[i] = if getmetatable(v :: any) == nil then {msg_type}.new(v) else v\n\
+                                    out[i] = if getmetatable(v :: any) == nil then {msg_type}.new(v :: any) else (v :: any) :: {msg_type_name}\n\
                                 end\n\
                                 return out\n\
                             end)(),"
@@ -590,10 +669,12 @@ impl FieldGenerator<'_> {
                         self.export_map,
                         self.base_file,
                     );
+                    let msg_type_name =
+                        type_definition_of_field_descriptor(field, self.export_map, self.base_file);
                     return format!(
                         "{field_name} = if data == nil or data.{field_name} == nil then {default} \
-                         elseif getmetatable(data.{field_name} :: any) == nil then {msg_type}.new(data.{field_name}) \
-                         else data.{field_name},"
+                         elseif getmetatable(data.{field_name} :: any) == nil then {msg_type}.new(data.{field_name} :: any) \
+                         else (data.{field_name} :: any) :: {msg_type_name},"
                     );
                 }
 
@@ -641,8 +722,8 @@ impl FieldGenerator<'_> {
                 }
                 body.push_str(
                     "end\n\
-                    return v\n\
-                end)(),"
+                    return v :: any\n\
+                end)(),",
                 );
                 body
             }
@@ -719,6 +800,57 @@ fn type_definition_of_field_descriptor(
     base_file: &FileDescriptorProto,
 ) -> String {
     definition_of_field_descriptor(field, export_map, base_file, "")
+}
+
+/// Type expression for an input position that accepts either a constructed
+/// message or a plain-table partial. For non-message fields, behaves the
+/// same as `type_definition_of_field_descriptor`.
+fn partial_input_definition_of_field_descriptor(
+    field: &FieldDescriptorProto,
+    export_map: &ExportMap,
+    base_file: &FileDescriptorProto,
+) -> String {
+    let typed = type_definition_of_field_descriptor(field, export_map, base_file);
+    if field.r#type() == Type::Message {
+        let partial = partial_fields_definition_of_field_descriptor(field, export_map, base_file);
+        format!("({typed} | {partial})")
+    } else {
+        typed
+    }
+}
+
+/// Path to the `_<Name>PartialFields` type for a message field, including
+/// any cross-file `<file_export>.` prefix.
+fn partial_fields_definition_of_field_descriptor(
+    field: &FieldDescriptorProto,
+    export_map: &ExportMap,
+    base_file: &FileDescriptorProto,
+) -> String {
+    let original_type_name = field.type_name();
+    assert!(
+        original_type_name.starts_with('.'),
+        "NYI: Relative type names: {original_type_name}"
+    );
+
+    let type_name = &original_type_name[1..];
+    let mut segments: Vec<&str> = type_name.split('.').collect();
+    let just_type = segments.pop().unwrap();
+    let package = segments.join(".");
+
+    let export = export_map
+        .get(&format!("{package}.{just_type}"))
+        .or_else(|| export_map.get(original_type_name))
+        .unwrap_or_else(|| panic!("couldn't find export {package}.{just_type}"));
+
+    if export.path == Path::new(base_file.name()).with_extension("") {
+        format!("_{}{just_type}PartialFields", export.prefix)
+    } else {
+        format!(
+            "{}._{}{just_type}PartialFields",
+            file_path_export_name(&export.path),
+            export.prefix,
+        )
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -516,6 +516,138 @@ impl FieldGenerator<'_> {
             FieldKind::OneOf { .. } => "nil".into(),
         }
     }
+
+    /// Emit the full `{field} = ...,` line for the `.new()` body.
+    ///
+    /// For message-typed fields (singular, repeated, map-value, oneof-case), plain-table
+    /// inputs are recursively wrapped with the nested message's `.new()` so that downstream
+    /// operations that require the metatable (`:jsonEncode()`, `:encode()`, etc.) work.
+    /// Already-typed instances (ones that carry a metatable) pass through unchanged.
+    ///
+    /// Mirrors the algorithm in protoc-gen-es's `create(Schema, plainObject)` — iterate
+    /// field descriptors, for each message-kind field auto-construct recursively.
+    pub fn new_body_assignment(&self) -> String {
+        let field_name = self.name();
+        let default = self.default();
+
+        match &self.field_kind {
+            FieldKind::Single(field) => {
+                // Maps are modeled at the proto level as `repeated MapEntry` but exposed here
+                // as a separate kind via `map_type()` — check that first.
+                if let Some(map_type) = self.map_type() {
+                    if map_type.value.r#type() == Type::Message {
+                        let value_type = runtime_definition_of_field_descriptor(
+                            &map_type.value,
+                            self.export_map,
+                            self.base_file,
+                        );
+                        return format!(
+                            "{field_name} = (function()\n\
+                                local src = if data == nil then nil else data.{field_name}\n\
+                                if src == nil then return {{}} end\n\
+                                local out = {{}}\n\
+                                for k, v in src do\n\
+                                    out[k] = if getmetatable(v :: any) == nil then {value_type}.new(v) else v\n\
+                                end\n\
+                                return out\n\
+                            end)(),"
+                        );
+                    }
+                    return format!(
+                        "{field_name} = if data == nil or data.{field_name} == nil then {default} else data.{field_name},"
+                    );
+                }
+
+                // Repeated scalar or repeated message.
+                if field.label.is_some() && field.label() == Label::Repeated {
+                    if field.r#type() == Type::Message {
+                        let msg_type = runtime_definition_of_field_descriptor(
+                            field,
+                            self.export_map,
+                            self.base_file,
+                        );
+                        return format!(
+                            "{field_name} = (function()\n\
+                                local src = if data == nil then nil else data.{field_name}\n\
+                                if src == nil then return {{}} end\n\
+                                local out = table.create(#src)\n\
+                                for i, v in src do\n\
+                                    out[i] = if getmetatable(v :: any) == nil then {msg_type}.new(v) else v\n\
+                                end\n\
+                                return out\n\
+                            end)(),"
+                        );
+                    }
+                    return format!(
+                        "{field_name} = if data == nil or data.{field_name} == nil then {default} else data.{field_name},"
+                    );
+                }
+
+                // Singular message field — auto-wrap plain tables.
+                if field.r#type() == Type::Message {
+                    let msg_type = runtime_definition_of_field_descriptor(
+                        field,
+                        self.export_map,
+                        self.base_file,
+                    );
+                    return format!(
+                        "{field_name} = if data == nil or data.{field_name} == nil then {default} \
+                         elseif getmetatable(data.{field_name} :: any) == nil then {msg_type}.new(data.{field_name}) \
+                         else data.{field_name},"
+                    );
+                }
+
+                // Scalar / enum / bytes / bool — pass through as today.
+                format!(
+                    "{field_name} = if data == nil or data.{field_name} == nil then {default} else data.{field_name},"
+                )
+            }
+
+            FieldKind::OneOf { fields, .. } => {
+                // Auto-wrap plain-table `value` when the tagged variant is a message case.
+                // Non-message cases (string/int/etc.) pass through unchanged.
+                let message_cases: Vec<(&FieldDescriptorProto, String, String)> = fields
+                    .iter()
+                    .filter(|f| f.r#type() == Type::Message)
+                    .map(|f| {
+                        let case_name = self.luau_name(f.name());
+                        let msg_type = runtime_definition_of_field_descriptor(
+                            f,
+                            self.export_map,
+                            self.base_file,
+                        );
+                        (*f, case_name, msg_type)
+                    })
+                    .collect();
+
+                if message_cases.is_empty() {
+                    return format!(
+                        "{field_name} = if data == nil or data.{field_name} == nil then nil else data.{field_name},"
+                    );
+                }
+
+                let mut body = String::new();
+                body.push_str(&format!(
+                    "{field_name} = (function()\n\
+                        if data == nil or data.{field_name} == nil then return nil end\n\
+                        local v = data.{field_name}\n"
+                ));
+                for (i, (_, case_name, msg_type)) in message_cases.iter().enumerate() {
+                    let keyword = if i == 0 { "if" } else { "elseif" };
+                    body.push_str(&format!(
+                        "{keyword} (v :: any).type == \"{case_name}\" and (v :: any).value ~= nil and getmetatable((v :: any).value) == nil then\n\
+                            return {{ type = (v :: any).type, value = {msg_type}.new((v :: any).value) }} :: any\n"
+                    ));
+                }
+                body.push_str(
+                    "end\n\
+                    return v\n\
+                end)(),"
+                );
+                body
+            }
+        }
+    }
 }
 
 fn definition_of_field_descriptor(

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -815,10 +815,7 @@ impl<'a> FileGenerator<'a> {
                 json_decode_lines.append(&mut field.json_decode());
             }
 
-            default_lines.push(format!(
-                r#"{field_name} = if data == nil or data.{field_name} == nil then {} else data.{field_name},"#,
-                field.default()
-            ));
+            default_lines.push(field.new_body_assignment());
 
             for inner_field in field.inner_fields() {
                 let output = &format!("self.{field_name}");

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -713,7 +713,7 @@ impl<'a> FileGenerator<'a> {
         fields_builder.push(format!(r#"type _{name}Fields = {{"#));
         fields_builder.indent();
 
-        partial_fields_builder.push(format!(r#"type _{name}PartialFields = {{"#));
+        partial_fields_builder.push(format!(r#"export type _{name}PartialFields = {{"#));
         partial_fields_builder.indent();
 
         let mut default_lines = StringBuilder::new();
@@ -802,7 +802,7 @@ impl<'a> FileGenerator<'a> {
             fields_builder.push(format!("{field_name}: {},", field.type_definition()));
             partial_fields_builder.push(format!(
                 "{field_name}: {}?,",
-                field.type_definition_no_presence()
+                field.partial_input_type_definition_no_presence()
             ));
 
             encode_lines.append(&mut field.encode());

--- a/src/luau_tests.rs
+++ b/src/luau_tests.rs
@@ -19,6 +19,7 @@ fn generate_samples() {
         "forwards_compatibility.proto",
         "kitchen_sink.proto",
         "many_messages.proto",
+        "nested_autowrap.proto",
         "recursive.proto",
         "wkt.proto",
     ];
@@ -206,4 +207,9 @@ async fn field_case_snake() {
 #[tokio::test]
 async fn field_case_camel() {
     run_luau_test(Path::new("field_case_camel.luau")).await;
+}
+
+#[tokio::test]
+async fn nested_autowrap() {
+    run_luau_test(Path::new("nested_autowrap.luau")).await;
 }

--- a/src/samples/protos/nested_autowrap.proto
+++ b/src/samples/protos/nested_autowrap.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package nested_autowrap;
+
+message Inner {
+	string value = 1;
+}
+
+message Other {
+	int32 n = 1;
+}
+
+message Container {
+	Inner single = 1;
+	repeated Inner items = 2;
+	map<string, Inner> entries = 3;
+
+	oneof payload {
+		Inner case_msg = 4;
+		string case_string = 5;
+		Other case_other = 6;
+	}
+}

--- a/src/tests/nested_autowrap.luau
+++ b/src/tests/nested_autowrap.luau
@@ -10,7 +10,7 @@ local it = tests.it
 
 local Container = nested_autowrap.Container
 local Inner = nested_autowrap.Inner
-local Other = nested_autowrap.Other
+local _Other = nested_autowrap.Other
 
 describe("nested_autowrap", function()
 	describe("singular message field", function()
@@ -18,6 +18,7 @@ describe("nested_autowrap", function()
 			local c = Container.new({
 				single = { value = "hello" },
 			})
+			assert(c.single, "expected c.single to be set")
 			assertEquals(c.single.value, "hello")
 			assert(getmetatable(c.single :: any) ~= nil, "expected c.single to have a metatable")
 		end)

--- a/src/tests/nested_autowrap.luau
+++ b/src/tests/nested_autowrap.luau
@@ -1,0 +1,153 @@
+--!strict
+-- Validates that .new() auto-wraps plain-table nested message fields into
+-- typed instances, and passes already-typed instances through unchanged.
+local tests = require("./tests")
+local nested_autowrap = require("./samples/nested_autowrap")
+
+local assertEquals = tests.assertEquals
+local describe = tests.describe
+local it = tests.it
+
+local Container = nested_autowrap.Container
+local Inner = nested_autowrap.Inner
+local Other = nested_autowrap.Other
+
+describe("nested_autowrap", function()
+	describe("singular message field", function()
+		it("wraps a plain table", function()
+			local c = Container.new({
+				single = { value = "hello" },
+			})
+			assertEquals(c.single.value, "hello")
+			assert(getmetatable(c.single :: any) ~= nil, "expected c.single to have a metatable")
+		end)
+
+		it("passes a typed instance through unchanged", function()
+			local inner = Inner.new({ value = "hello" })
+			local c = Container.new({ single = inner })
+			assertEquals(c.single, inner)
+		end)
+	end)
+
+	describe("repeated message field", function()
+		it("wraps each plain-table element", function()
+			local c = Container.new({
+				items = { { value = "a" }, { value = "b" } },
+			})
+			assertEquals(#c.items, 2)
+			assertEquals(c.items[1].value, "a")
+			assertEquals(c.items[2].value, "b")
+			assert(getmetatable(c.items[1] :: any) ~= nil, "expected items[1] to have a metatable")
+			assert(getmetatable(c.items[2] :: any) ~= nil, "expected items[2] to have a metatable")
+		end)
+
+		it("passes typed-instance elements through", function()
+			local a = Inner.new({ value = "a" })
+			local b = Inner.new({ value = "b" })
+			local c = Container.new({ items = { a, b } })
+			assertEquals(c.items[1], a)
+			assertEquals(c.items[2], b)
+		end)
+	end)
+
+	describe("map<string, message>", function()
+		it("wraps each plain-table value", function()
+			local c = Container.new({
+				entries = { foo = { value = "x" }, bar = { value = "y" } },
+			})
+			assertEquals(c.entries.foo.value, "x")
+			assertEquals(c.entries.bar.value, "y")
+			assert(getmetatable(c.entries.foo :: any) ~= nil, "expected entries.foo to have a metatable")
+			assert(getmetatable(c.entries.bar :: any) ~= nil, "expected entries.bar to have a metatable")
+		end)
+
+		it("passes typed-instance values through", function()
+			local foo = Inner.new({ value = "x" })
+			local c = Container.new({ entries = { foo = foo } })
+			assertEquals(c.entries.foo, foo)
+		end)
+	end)
+
+	describe("oneof with message case", function()
+		it("wraps the plain-table value of a message case", function()
+			local c = Container.new({
+				payload = { type = "case_msg", value = { value = "z" } },
+			})
+			assertEquals((c.payload :: any).type, "case_msg")
+			assertEquals((c.payload :: any).value.value, "z")
+			assert(
+				getmetatable((c.payload :: any).value) ~= nil,
+				"expected payload.value to have a metatable"
+			)
+		end)
+
+		it("wraps a second message-typed case too", function()
+			local c = Container.new({
+				payload = { type = "case_other", value = { n = 42 } },
+			})
+			assertEquals((c.payload :: any).value.n, 42)
+			assert(
+				getmetatable((c.payload :: any).value) ~= nil,
+				"expected payload.value to have a metatable"
+			)
+		end)
+
+		it("passes typed-instance value through", function()
+			local inner = Inner.new({ value = "z" })
+			local c = Container.new({
+				payload = { type = "case_msg", value = inner },
+			})
+			assertEquals((c.payload :: any).value, inner)
+		end)
+
+		it("leaves non-message oneof variants (string) untouched", function()
+			local c = Container.new({
+				payload = { type = "case_string", value = "plain" },
+			})
+			assertEquals((c.payload :: any).type, "case_string")
+			assertEquals((c.payload :: any).value, "plain")
+		end)
+	end)
+
+	describe("round-trip through encode/decode", function()
+		it("jsonEncode + jsonDecode works on plain-input construction", function()
+			local c = Container.new({
+				single = { value = "s" },
+				items = { { value = "a" }, { value = "b" } },
+				entries = { k = { value = "v" } },
+				payload = { type = "case_msg", value = { value = "p" } },
+			})
+
+			local json = c:jsonEncode()
+			local decoded = Container.jsonDecode(json)
+
+			assert(decoded.single ~= nil, "expected decoded.single")
+			assertEquals((decoded.single :: any).value, "s")
+			assertEquals(#decoded.items, 2)
+			assertEquals((decoded.items[1] :: any).value, "a")
+			assertEquals((decoded.entries.k :: any).value, "v")
+			assertEquals((decoded.payload :: any).type, "case_msg")
+			assertEquals((decoded.payload :: any).value.value, "p")
+		end)
+
+		it("binary encode + decode works on plain-input construction", function()
+			local c = Container.new({
+				single = { value = "s" },
+				items = { { value = "a" } },
+				entries = { k = { value = "v" } },
+				payload = { type = "case_other", value = { n = 7 } },
+			})
+
+			local buf = c:encode()
+			local decoded = Container.decode(buf)
+
+			assertEquals((decoded.single :: any).value, "s")
+			assertEquals((decoded.items[1] :: any).value, "a")
+			assertEquals((decoded.entries.k :: any).value, "v")
+			assertEquals((decoded.payload :: any).type, "case_other")
+			assertEquals((decoded.payload :: any).value.n, 7)
+		end)
+	end)
+end)
+
+tests.finish()


### PR DESCRIPTION
.new(partialFields) on a generated message now recursively wraps plain-table values for message-kind fields with the nested message's .new(), so downstream :encode()/:jsonEncode() work without callers hand-constructing typed instances. Typed instances pass through unchanged (guarded by getmetatable == nil).

Covers singular, repeated, map<_, message>, and oneof message cases — mirrors protoc-gen-es's create(Schema, plainObject) precedent.

Adds src/samples/protos/nested_autowrap.proto + src/tests/nested_autowrap.luau with round-trip encode/decode and idempotency coverage.